### PR TITLE
fix: frontend deps and log framework

### DIFF
--- a/frontend/lib/core/logger.dart
+++ b/frontend/lib/core/logger.dart
@@ -1,0 +1,5 @@
+import 'package:logger/logger.dart';
+
+Logger getLogger() {
+  return Logger();
+}

--- a/frontend/lib/service/auth/auth_service.dart
+++ b/frontend/lib/service/auth/auth_service.dart
@@ -2,10 +2,12 @@ import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:nibbles/core/dio_client.dart';
+import 'package:nibbles/core/logger.dart';
 
 class AuthService {
   final Dio _dio = DioClient().client;
   final _storage = FlutterSecureStorage();
+  final _logger = getLogger();
   final GoogleSignIn _googleSignIn = GoogleSignIn(
     clientId: 'to_do',
     scopes: ['email', 'profile'],
@@ -19,38 +21,38 @@ class AuthService {
 
   Future<bool> loginWithEmail(String email, String password) async {
     try {
-      print('Attempting login with email: $email');
+      _logger.d('Attempting login with email: $email');
       final response = await _dio.post(
         'auth/login',
         data: {'email': email, 'password': password},
       );
-      print('Received response: ${response.data}');
+      _logger.d('Received response: ${response.data}');
       await _saveTokens(response.data);
       return true;
     } catch (e) {
-      print('Login error: $e');
+      _logger.d('Login error: $e');
       return false;
     }
   }
 
   Future<bool> loginWithGoogle() async {
     try {
-      print('Attempting Google login');
+      _logger.d('Attempting Google login');
       final googleUser = await _googleSignIn.signIn();
 
       if (googleUser == null) {
-        print('Google sign-in was cancelled');
+        _logger.d('Google sign-in was cancelled');
         return false;
       }
 
       final googleAuth = await googleUser.authentication;
 
       if (googleAuth.idToken == null) {
-        print('Google idToken is null, cannot proceed');
+        _logger.d('Google idToken is null, cannot proceed');
         return false;
       }
 
-      print('Google idToken: ${googleAuth.idToken}');
+      _logger.d('Google idToken: ${googleAuth.idToken}');
 
       // Send id_token to your backend
       final response = await _dio.post(
@@ -58,12 +60,12 @@ class AuthService {
         data: {'idToken': googleAuth.idToken},
       );
 
-      print('Received response: ${response.data}');
+      _logger.d('Received response: ${response.data}');
       await _saveTokens(response.data);
       return true;
     } catch (e, stackTrace) {
-      print("Google login failed with error: $e");
-      print("Stack trace: $stackTrace");
+      _logger.d("Google login failed with error: $e");
+      _logger.d("Stack trace: $stackTrace");
       return false;
     }
   }
@@ -75,8 +77,8 @@ class AuthService {
     String password,
   ) async {
     try {
-      print('Attempting registration for: $email');
-      print(
+      _logger.d('Attempting registration for: $email');
+      _logger.d(
         'Registration payload: {email: $email, firstName: $firstName, lastName: $lastName, password: $password}',
       );
       final response = await _dio.post(
@@ -88,42 +90,42 @@ class AuthService {
           'password': password,
         },
       );
-      print('Registration response: ${response.data}');
+      _logger.d('Registration response: ${response.data}');
       return true;
     } catch (e) {
-      print('Registration error: $e');
+      _logger.d('Registration error: $e');
       return false;
     }
   }
 
   Future<bool> verifyEmail(String email, String code) async {
     try {
-      print('Verifying email: $email with code: $code');
+      _logger.d('Verifying email: $email with code: $code');
       final response = await _dio.post(
         'auth/verify',
         data: {'email': email, 'code': code},
       );
-      print('Verification response status: ${response.statusCode}');
-      print('Received response: ${response.data}');
+      _logger.d('Verification response status: ${response.statusCode}');
+      _logger.d('Received response: ${response.data}');
       await _saveTokens(response.data);
       return true;
     } catch (e) {
-      print('Verification error: $e');
+      _logger.d('Verification error: $e');
       return false;
     }
   }
 
   Future<bool> newVerification(String email) async {
     try {
-      print('Requesting new verification for: $email');
+      _logger.d('Requesting new verification for: $email');
       final response = await _dio.post(
         'auth/new-verification',
         data: {'email': email},
       );
-      print('New verification response: ${response.statusCode}');
+      _logger.d('New verification response: ${response.statusCode}');
       return response.statusCode == 201;
     } catch (e) {
-      print('New verification error: $e');
+      _logger.d('New verification error: $e');
       return false;
     }
   }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -42,7 +42,7 @@ packages:
     source: hosted
     version: "1.19.1"
   dio:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: dio
       sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
@@ -79,7 +79,7 @@ packages:
     source: hosted
     version: "5.0.0"
   flutter_secure_storage:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: flutter_secure_storage
       sha256: "22dbf16f23a4bcf9d35e51be1c84ad5bb6f627750565edd70dab70f3ff5fff8f"
@@ -145,7 +145,7 @@ packages:
     source: hosted
     version: "0.3.3+1"
   google_sign_in:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: google_sign_in
       sha256: d0a2c3bcb06e607bb11e4daca48bd4b6120f0bbc4015ccebbe757d24ea60ed2a
@@ -240,6 +240,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.0"
   matcher:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -9,14 +9,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  logger: ^2.5.0
+  flutter_secure_storage: ^8.0.0
+  dio: ^5.4.0
+  google_sign_in: ^6.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
-  flutter_secure_storage: ^8.0.0
-  dio: ^5.4.0
-  google_sign_in: ^6.1.4
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Dio, GoogleSignIn, and SecureStorage need to be client side dependencies, not dev-only, as they must be bundled in to the final build.

See the following docs on installation procedure for each which advises to nest under the `dependencies` (not `dev_dependencies`) section in `pubspec.yaml`:
https://pub.dev/packages/dio/install
https://pub.dev/packages/flutter_secure_storage/install
https://pub.dev/packages/google_sign_in/install

This PR also adds a logging framework to remove the warnings associated with using `print` in a production-grade project.