### PR TITLE
fix: app launch on web

### DIFF
--- a/frontend/android/app/build.gradle.kts
+++ b/frontend/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.nibbles"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <application
         android:label="nibbles"
         android:name="${applicationName}"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/frontend/lib/core/dio_client.dart
+++ b/frontend/lib/core/dio_client.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:nibbles/core/logger.dart';
 import '../main.dart'; // Import navigatorKey
-import 'dart:io';
+import 'package:flutter/foundation.dart';
 
 class DioClient {
   static final DioClient _instance = DioClient._internal();
@@ -11,9 +11,9 @@ class DioClient {
   final Dio _dio = Dio(
     BaseOptions(
       baseUrl:
-          Platform.isAndroid
-              ? 'http://10.0.2.2:3000/api/'
-              : 'http://localhost:3000/api/',
+          kIsWeb || defaultTargetPlatform != TargetPlatform.android
+              ? 'http://localhost:3000/api/'
+              : 'http://10.0.2.2:3000/api/',
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 10),
       validateStatus: (status) => status != null && status < 400,

--- a/frontend/lib/service/auth/auth_service.dart
+++ b/frontend/lib/service/auth/auth_service.dart
@@ -4,7 +4,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:nibbles/core/constants.dart';
 import 'package:nibbles/core/dio_client.dart';
 import 'package:nibbles/core/logger.dart';
-import 'dart:io';
+import 'package:flutter/foundation.dart';
 
 class AuthService {
   final Dio _dio = DioClient().client;
@@ -15,7 +15,7 @@ class AuthService {
   late GoogleSignIn _googleSignIn;
 
   AuthService() {
-    if (Platform.isIOS) {
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
       _googleSignIn = GoogleSignIn(
         clientId: AppConstants.googleClientId,
         scopes: ['email'],


### PR DESCRIPTION
Although our app is only intended for Android, at least for the MVP, it's great to be able to test the app in Chrome without spinning up the emulator (and also far less demanding for some computers).

Currently, the use of dart:io for the Platform check breaks, because the Platform (API?) is not available on Web.

According to this StackOverflow post, the best way to fix that is to use the more modern Foundation (API?) to check the platform:

https://stackoverflow.com/questions/58459483/unsupported-operation-platform-operatingsystem

UPDATE 1: I've also pushed a commit that comments out the ndk version so that when building for Android it uses the one bundled with the SDK which should be more up-to-date (also removes an error in compilation)

UPDATE 2: I've also pushed a commit for enabling back invoked callback. See thread here for explanation: https://stackoverflow.com/questions/73782320/onbackinvokedcallback-is-not-enabled-for-the-application-in-set-androidenableo . It's to enable a predictive back gesture, so no biggie.