### PR TITLE
feat: 2.0 recipe recommendations

### DIFF
--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'dart:convert';
+
+class RecipePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Based on Your Ingredients:'),
+        backgroundColor: Color(0xFFB4436C), // The color from the screenshot
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: ListView.builder(
+          itemCount: recipes.length,
+          itemBuilder: (context, index) {
+            return Card(
+              margin: EdgeInsets.symmetric(vertical: 10),
+              elevation: 4,
+              child: ListTile(
+                contentPadding: EdgeInsets.all(16),
+                title: Text(recipes[index]['title']!),
+                subtitle: Row(
+                  children: [
+                    Icon(
+                      Icons.access_time,
+                      size: 16,
+                    ),
+                    SizedBox(width: 5),
+                    Text(recipes[index]['time']!),
+                    SizedBox(width: 20),
+                    Text(
+                      recipes[index]['difficulty']!,
+                      style: TextStyle(
+                        color: _getDifficultyColor(recipes[index]['difficulty']!),
+                      ),
+                    ),
+                  ],
+                ),
+                trailing: IconButton(
+                  icon: Icon(Icons.favorite_border),
+                  onPressed: () {
+                    // Implement the favorite functionality here
+                  },
+                ),
+                onTap: () {
+                  // Implement tap action here (e.g., go to recipe details page)
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  // Function to determine the difficulty color
+  Color _getDifficultyColor(String difficulty) {
+    if (difficulty == 'Hard') {
+      return Colors.red;
+    } else if (difficulty == 'Medium') {
+      return Colors.orange;
+    } else {
+      return Colors.green;
+    }
+  }
+}

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -7,7 +7,8 @@ class RecipeRecommendationsPage extends StatefulWidget {
   const RecipeRecommendationsPage({super.key});
 
   @override
-  State<RecipeRecommendationsPage> createState() => _RecipeRecommendationsPageState();
+  State<RecipeRecommendationsPage> createState() =>
+      _RecipeRecommendationsPageState();
 }
 
 class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
@@ -53,17 +54,16 @@ class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
     }
   }
 
-void _toggleFavorite(int index) {
-  setState(() {
-    recipes[index].isFavorite = !recipes[index].isFavorite;
-  });
-}
+  void _toggleFavorite(int index) {
+    setState(() {
+      recipes[index].isFavorite = !recipes[index].isFavorite;
+    });
+  }
 
-void _reloadRecipes() {
-  // Logic to reload recipes or update the list goes here
-  print("Recipes reloaded!");
-}
-
+  void _reloadRecipes() {
+    // Logic to reload recipes or update the list goes here
+    print("Recipes reloaded!");
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -84,27 +84,24 @@ void _reloadRecipes() {
             color: colorScheme.onSurface,
           ),
         ),
-actions: [
-  IconButton(
-    icon: Icon(Icons.refresh, color: colorScheme.onSurface),
-    tooltip: 'Refresh',
-    onPressed: _reloadRecipes,
-    // currently not doing anything but when backend is ready it will be implemented to refresh the recipes.
-  ),
-  IconButton(
-    icon: Icon(Icons.filter_list, color: colorScheme.onSurface),
-    tooltip: 'Filter',
-    onPressed: () {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (context) => const RecipesPage(),
-        ),
-      );
-    },
-  ),
-],
-
+        actions: [
+          IconButton(
+            icon: Icon(Icons.refresh, color: colorScheme.onSurface),
+            tooltip: 'Refresh',
+            onPressed: _reloadRecipes,
+            // currently not doing anything but when backend is ready it will be implemented to refresh the recipes.
+          ),
+          IconButton(
+            icon: Icon(Icons.filter_list, color: colorScheme.onSurface),
+            tooltip: 'Filter',
+            onPressed: () {
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(builder: (context) => const RecipesPage()),
+              );
+            },
+          ),
+        ],
       ),
       body: ListView.builder(
         padding: const EdgeInsets.all(16),
@@ -157,7 +154,10 @@ actions: [
                             vertical: 4,
                           ),
                           decoration: BoxDecoration(
-                            color: _getDifficultyColor(recipe.difficulty, colorScheme),
+                            color: _getDifficultyColor(
+                              recipe.difficulty,
+                              colorScheme,
+                            ),
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: Text(
@@ -189,20 +189,29 @@ actions: [
                           children: [
                             Row(
                               children: [
-                                Icon(Icons.access_time, size: 16, color: colorScheme.onSurfaceVariant),
+                                Icon(
+                                  Icons.access_time,
+                                  size: 16,
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
                                 const SizedBox(width: 4),
                                 Text(
                                   '${recipe.cookingTime} min',
-                                  style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
+                                  style: textTheme.labelMedium?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
                                 ),
                               ],
                             ),
                             IconButton(
                               icon: Icon(
-                                recipe.isFavorite ? Icons.favorite : Icons.favorite_border,
-                                color: recipe.isFavorite
-                                    ? Colors.red.shade800
-                                    : colorScheme.onSurfaceVariant,
+                                recipe.isFavorite
+                                    ? Icons.favorite
+                                    : Icons.favorite_border,
+                                color:
+                                    recipe.isFavorite
+                                        ? Colors.red.shade800
+                                        : colorScheme.onSurfaceVariant,
                               ),
                               onPressed: () => _toggleFavorite(index),
                             ),

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -89,6 +89,7 @@ actions: [
     icon: Icon(Icons.refresh, color: colorScheme.onSurface),
     tooltip: 'Refresh',
     onPressed: _reloadRecipes,
+    // currently not doing anything but when backend is ready it will be implemented to refresh the recipes.
   ),
   IconButton(
     icon: Icon(Icons.filter_list, color: colorScheme.onSurface),

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -62,7 +62,7 @@ class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
 
   void _reloadRecipes() {
     // Logic to reload recipes or update the list goes here
-    print("Recipes reloaded!");
+    // Removed print to comply with production code standards
   }
 
   @override
@@ -89,7 +89,6 @@ class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
             icon: Icon(Icons.refresh, color: colorScheme.onSurface),
             tooltip: 'Refresh',
             onPressed: _reloadRecipes,
-            // currently not doing anything but when backend is ready it will be implemented to refresh the recipes.
           ),
           IconButton(
             icon: Icon(Icons.filter_list, color: colorScheme.onSurface),
@@ -124,7 +123,7 @@ class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
                 borderRadius: BorderRadius.circular(16),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withOpacity(0.05),
+                    color: Colors.black.withAlpha((0.05 * 255).round()),
                     blurRadius: 6,
                     offset: const Offset(0, 4),
                   ),
@@ -208,10 +207,9 @@ class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
                                 recipe.isFavorite
                                     ? Icons.favorite
                                     : Icons.favorite_border,
-                                color:
-                                    recipe.isFavorite
-                                        ? Colors.red.shade800
-                                        : colorScheme.onSurfaceVariant,
+                                color: recipe.isFavorite
+                                    ? Colors.red.shade800
+                                    : colorScheme.onSurfaceVariant,
                               ),
                               onPressed: () => _toggleFavorite(index),
                             ),

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -1,7 +1,69 @@
 import 'package:flutter/material.dart';
-import 'dart:convert';
+import 'recipe_ingredients_page.dart';
 
-class RecipePage extends StatelessWidget {
+class RecipePage extends StatefulWidget {
+  const RecipePage({super.key});
+
+  @override
+  State<RecipePage> createState() => _RecipePageState();
+}
+
+class _RecipePageState extends State<RecipePage> {
+  // Sample data for recipes
+  final List<List<Map<String, String>>> recipePages = [
+    [
+      {
+        'title': 'Traditional spare ribs baked',
+        'time': '55 min',
+        'difficulty': 'Hard',
+        'image': 'assets/images/spare_ribs.jpg',
+      },
+      {
+        'title': 'Spice Roasted Chicken with Flavored Rice',
+        'time': '30 min',
+        'difficulty': 'Medium',
+        'image': 'assets/images/roasted_chicken.jpg',
+      },
+      {
+        'title': 'Spicy fried rice mix chicken bali',
+        'time': '25 min',
+        'difficulty': 'Medium',
+        'image': 'assets/images/fried_rice.jpg',
+      },
+    ],
+    [
+      {
+        'title': 'Grilled Salmon with Lemon Butter',
+        'time': '40 min',
+        'difficulty': 'Easy',
+        'image': 'assets/images/grilled_salmon.jpg',
+      },
+      {
+        'title': 'Vegetarian Pasta Primavera',
+        'time': '35 min',
+        'difficulty': 'Easy',
+        'image': 'assets/images/pasta_primavera.jpg',
+      },
+      {
+        'title': 'Beef Stroganoff',
+        'time': '50 min',
+        'difficulty': 'Hard',
+        'image': 'assets/images/beef_stroganoff.jpg',
+      },
+    ],
+  ];
+
+    // Function to determine the difficulty color
+  Color _getDifficultyColor(String difficulty) {
+    if (difficulty == 'Hard') { // hard will be red 
+      return Colors.red;
+    } else if (difficulty == 'Medium') { // medium will be orange
+      return Colors.orange;
+    } else {
+      return Colors.green; // easy will be green
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -54,14 +116,4 @@ class RecipePage extends StatelessWidget {
     );
   }
 
-  // Function to determine the difficulty color
-  Color _getDifficultyColor(String difficulty) {
-    if (difficulty == 'Hard') {
-      return Colors.red;
-    } else if (difficulty == 'Medium') {
-      return Colors.orange;
-    } else {
-      return Colors.green;
-    }
   }
-}

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -54,28 +54,43 @@ class _RecipeFormatPageState extends State<RecipeFormatPage> {
     });
   }
 
-  @override
+  void _reloadRecipes() {
+    // Logic to reload recipes or update the list goes here
+    print("Recipes reloaded!");
+  }
+
+  void _openFilter() {
+    // Logic to open filter dialog or page goes here
+    print("Filter opened!");
+  }
+
+@override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFFF5F5F5),
+      appBar: AppBar(
+        title: const Text(
+          'Based on your ingredients:',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        backgroundColor: const Color(0xFFB4436C),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _reloadRecipes, // Reload function
+            tooltip: 'Reload',
+          ),
+          IconButton(
+            icon: const Icon(Icons.filter_list),
+            onPressed: () {
+              Navigator.pop(context); // Go back to previous screen
+            },
+            tooltip: 'Filter',
+          ),
+        ],
+      ),
       body: Column(
         children: [
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.fromLTRB(20, 60, 20, 20),
-            decoration: const BoxDecoration(
-              color: Color(0xFFB4436C),
-              borderRadius: BorderRadius.vertical(bottom: Radius.circular(30)),
-            ),
-            child: const Text(
-              'Based on your\ningredients:',
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
           Expanded(
             child: ListView.builder(
               padding: const EdgeInsets.all(16),

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -1,22 +1,27 @@
 import 'package:flutter/material.dart';
 import 'recipe_ingredients_page.dart';
 import 'recipe_model.dart';
+import 'package:nibbles/pages/recipes/recipes_page.dart';
 
-class RecipeFormatPage extends StatefulWidget {
-  const RecipeFormatPage({super.key});
+class RecipeRecommendationsPage extends StatefulWidget {
+  const RecipeRecommendationsPage({super.key});
 
   @override
-  State<RecipeFormatPage> createState() => _RecipeFormatPageState();
+  State<RecipeRecommendationsPage> createState() => _RecipeRecommendationsPageState();
 }
 
-class _RecipeFormatPageState extends State<RecipeFormatPage> {
+class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
   final List<Recipe> recipes = [
     Recipe(
       title: 'Traditional spare ribs baked',
       imageUrl: 'assets/images/spare_ribs.jpg',
       cookingTime: 55,
       ingredients: ['Pork', 'Garlic', 'Soy Sauce', 'Sugar'],
-      instructions: ['Preheat oven to 180°C', 'Season ribs', 'Bake for 55 minutes'],
+      instructions: [
+        'Preheat oven to 180°C',
+        'Season ribs',
+        'Bake for 55 minutes',
+      ],
       isFavorite: false,
     ),
     Recipe(
@@ -37,168 +42,179 @@ class _RecipeFormatPageState extends State<RecipeFormatPage> {
     ),
   ];
 
-  Color _getDifficultyColor(String difficulty) {
+  Color _getDifficultyColor(String difficulty, ColorScheme colorScheme) {
     switch (difficulty) {
       case 'Hard':
         return Colors.red;
       case 'Medium':
         return Colors.orange;
       default:
-        return Colors.green;
+        return colorScheme.primary;
     }
   }
 
-  void _toggleFavorite(int index) {
-    setState(() {
-      recipes[index].isFavorite = !recipes[index].isFavorite;
-    });
-  }
+void _toggleFavorite(int index) {
+  setState(() {
+    recipes[index].isFavorite = !recipes[index].isFavorite;
+  });
+}
 
-  void _reloadRecipes() {
-    // Logic to reload recipes or update the list goes here
-    print("Recipes reloaded!");
-  }
+void _reloadRecipes() {
+  // Logic to reload recipes or update the list goes here
+  print("Recipes reloaded!");
+}
 
-  void _openFilter() {
-    // Logic to open filter dialog or page goes here
-    print("Filter opened!");
-  }
 
-@override
+  @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
     return Scaffold(
-      backgroundColor: const Color(0xFFF5F5F5),
+      backgroundColor: colorScheme.surface,
       appBar: AppBar(
-        title: const Text(
+        backgroundColor: colorScheme.surface,
+        elevation: 0,
+        leading: BackButton(color: colorScheme.onSurface),
+        centerTitle: false,
+        title: Text(
           'Based on your ingredients:',
-          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          style: textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: colorScheme.onSurface,
+          ),
         ),
-        backgroundColor: const Color(0xFFB4436C),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: _reloadRecipes, // Reload function
-            tooltip: 'Reload',
-          ),
-          IconButton(
-            icon: const Icon(Icons.filter_list),
-            onPressed: () {
-              Navigator.pop(context); // Go back to previous screen
-            },
-            tooltip: 'Filter',
-          ),
-        ],
+actions: [
+  IconButton(
+    icon: Icon(Icons.refresh, color: colorScheme.onSurface),
+    tooltip: 'Refresh',
+    onPressed: _reloadRecipes,
+  ),
+  IconButton(
+    icon: Icon(Icons.filter_list, color: colorScheme.onSurface),
+    tooltip: 'Filter',
+    onPressed: () {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const RecipesPage(),
+        ),
+      );
+    },
+  ),
+],
+
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: recipes.length,
-              itemBuilder: (context, index) {
-                final recipe = recipes[index];
-                return GestureDetector(
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => RecipeIngredientsPage(),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: recipes.length,
+        itemBuilder: (context, index) {
+          final recipe = recipes[index];
+          return GestureDetector(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const RecipeIngredientsPage(),
+                ),
+              );
+            },
+            child: Container(
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.05),
+                    blurRadius: 6,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Column(
+                children: [
+                  Stack(
+                    children: [
+                      ClipRRect(
+                        borderRadius: const BorderRadius.vertical(
+                          top: Radius.circular(16),
+                        ),
+                        child: Image.asset(
+                          recipe.imageUrl,
+                          height: 160,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                        ),
                       ),
-                    );
-                  },
-                  child: Container(
-                    margin: const EdgeInsets.only(bottom: 16),
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(16),
-                      boxShadow: const [
-                        BoxShadow(
-                          color: Colors.black12,
-                          blurRadius: 4,
-                          offset: Offset(0, 2),
-                        )
-                      ],
-                    ),
-                    child: Column(
-                      children: [
-                        Stack(
-                          children: [
-                            ClipRRect(
-                              borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-                              child: Image.asset(
-                                recipe.imageUrl,
-                                height: 160,
-                                width: double.infinity,
-                                fit: BoxFit.cover,
-                              ),
+                      Positioned(
+                        right: 10,
+                        top: 10,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: _getDifficultyColor(recipe.difficulty, colorScheme),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            recipe.difficulty,
+                            style: textTheme.labelSmall?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
                             ),
-                            Positioned(
-                              right: 10,
-                              top: 10,
-                              child: Container(
-                                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                                decoration: BoxDecoration(
-                                  color: _getDifficultyColor(recipe.difficulty),
-                                  borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(12.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          recipe.title,
+                          style: textTheme.bodyLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: colorScheme.onSurface,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Row(
+                              children: [
+                                Icon(Icons.access_time, size: 16, color: colorScheme.onSurfaceVariant),
+                                const SizedBox(width: 4),
+                                Text(
+                                  '${recipe.cookingTime} min',
+                                  style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
                                 ),
-                                child: Text(
-                                  recipe.difficulty,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
+                              ],
+                            ),
+                            IconButton(
+                              icon: Icon(
+                                recipe.isFavorite ? Icons.favorite : Icons.favorite_border,
+                                color: recipe.isFavorite
+                                    ? Colors.red.shade800
+                                    : colorScheme.onSurfaceVariant,
                               ),
+                              onPressed: () => _toggleFavorite(index),
                             ),
                           ],
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(12.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                recipe.title,
-                                style: const TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                              const SizedBox(height: 8),
-                              Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Row(
-                                    children: [
-                                      const Icon(Icons.access_time, size: 16),
-                                      const SizedBox(width: 4),
-                                      Text('${recipe.cookingTime} min'),
-                                    ],
-                                  ),
-                                  IconButton(
-                                    icon: Icon(
-                                      recipe.isFavorite
-                                          ? Icons.favorite
-                                          : Icons.favorite_border,
-                                      color: recipe.isFavorite
-                                          ? Colors.red.shade800
-                                          : null, // dark red when filled
-                                    ),
-                                    onPressed: () => _toggleFavorite(index),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ),
                         ),
                       ],
                     ),
                   ),
-                );
-              },
+                ],
+              ),
             ),
-          ),
-        ],
+          );
+        },
       ),
     );
   }

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -207,9 +207,10 @@ class _RecipeRecommendationsPageState extends State<RecipeRecommendationsPage> {
                                 recipe.isFavorite
                                     ? Icons.favorite
                                     : Icons.favorite_border,
-                                color: recipe.isFavorite
-                                    ? Colors.red.shade800
-                                    : colorScheme.onSurfaceVariant,
+                                color:
+                                    recipe.isFavorite
+                                        ? Colors.red.shade800
+                                        : colorScheme.onSurfaceVariant,
                               ),
                               onPressed: () => _toggleFavorite(index),
                             ),

--- a/frontend/lib/pages/recipes/recipe_recommendations_page.dart
+++ b/frontend/lib/pages/recipes/recipe_recommendations_page.dart
@@ -1,119 +1,190 @@
 import 'package:flutter/material.dart';
 import 'recipe_ingredients_page.dart';
+import 'recipe_model.dart';
 
-class RecipePage extends StatefulWidget {
-  const RecipePage({super.key});
+class RecipeFormatPage extends StatefulWidget {
+  const RecipeFormatPage({super.key});
 
   @override
-  State<RecipePage> createState() => _RecipePageState();
+  State<RecipeFormatPage> createState() => _RecipeFormatPageState();
 }
 
-class _RecipePageState extends State<RecipePage> {
-  // Sample data for recipes
-  final List<List<Map<String, String>>> recipePages = [
-    [
-      {
-        'title': 'Traditional spare ribs baked',
-        'time': '55 min',
-        'difficulty': 'Hard',
-        'image': 'assets/images/spare_ribs.jpg',
-      },
-      {
-        'title': 'Spice Roasted Chicken with Flavored Rice',
-        'time': '30 min',
-        'difficulty': 'Medium',
-        'image': 'assets/images/roasted_chicken.jpg',
-      },
-      {
-        'title': 'Spicy fried rice mix chicken bali',
-        'time': '25 min',
-        'difficulty': 'Medium',
-        'image': 'assets/images/fried_rice.jpg',
-      },
-    ],
-    [
-      {
-        'title': 'Grilled Salmon with Lemon Butter',
-        'time': '40 min',
-        'difficulty': 'Easy',
-        'image': 'assets/images/grilled_salmon.jpg',
-      },
-      {
-        'title': 'Vegetarian Pasta Primavera',
-        'time': '35 min',
-        'difficulty': 'Easy',
-        'image': 'assets/images/pasta_primavera.jpg',
-      },
-      {
-        'title': 'Beef Stroganoff',
-        'time': '50 min',
-        'difficulty': 'Hard',
-        'image': 'assets/images/beef_stroganoff.jpg',
-      },
-    ],
+class _RecipeFormatPageState extends State<RecipeFormatPage> {
+  final List<Recipe> recipes = [
+    Recipe(
+      title: 'Traditional spare ribs baked',
+      imageUrl: 'assets/images/spare_ribs.jpg',
+      cookingTime: 55,
+      ingredients: ['Pork', 'Garlic', 'Soy Sauce', 'Sugar'],
+      instructions: ['Preheat oven to 180°C', 'Season ribs', 'Bake for 55 minutes'],
+      isFavorite: false,
+    ),
+    Recipe(
+      title: 'Spice Roasted Chicken with Flavored Rice',
+      imageUrl: 'assets/images/roasted_chicken.jpg',
+      cookingTime: 30,
+      ingredients: ['Chicken', 'Rice', 'Spices'],
+      instructions: ['Marinate chicken', 'Roast for 30 minutes', 'Cook rice'],
+      isFavorite: false,
+    ),
+    Recipe(
+      title: 'Spicy fried rice mix chicken bali',
+      imageUrl: 'assets/images/fried_rice.jpg',
+      cookingTime: 25,
+      ingredients: ['Chicken', 'Rice', 'Chili'],
+      instructions: ['Fry ingredients', 'Add rice and spices', 'Serve hot'],
+      isFavorite: false,
+    ),
   ];
 
-    // Function to determine the difficulty color
   Color _getDifficultyColor(String difficulty) {
-    if (difficulty == 'Hard') { // hard will be red 
-      return Colors.red;
-    } else if (difficulty == 'Medium') { // medium will be orange
-      return Colors.orange;
-    } else {
-      return Colors.green; // easy will be green
+    switch (difficulty) {
+      case 'Hard':
+        return Colors.red;
+      case 'Medium':
+        return Colors.orange;
+      default:
+        return Colors.green;
     }
+  }
+
+  void _toggleFavorite(int index) {
+    setState(() {
+      recipes[index].isFavorite = !recipes[index].isFavorite;
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text('Based on Your Ingredients:'),
-        backgroundColor: Color(0xFFB4436C), // The color from the screenshot
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: ListView.builder(
-          itemCount: recipes.length,
-          itemBuilder: (context, index) {
-            return Card(
-              margin: EdgeInsets.symmetric(vertical: 10),
-              elevation: 4,
-              child: ListTile(
-                contentPadding: EdgeInsets.all(16),
-                title: Text(recipes[index]['title']!),
-                subtitle: Row(
-                  children: [
-                    Icon(
-                      Icons.access_time,
-                      size: 16,
-                    ),
-                    SizedBox(width: 5),
-                    Text(recipes[index]['time']!),
-                    SizedBox(width: 20),
-                    Text(
-                      recipes[index]['difficulty']!,
-                      style: TextStyle(
-                        color: _getDifficultyColor(recipes[index]['difficulty']!),
-                      ),
-                    ),
-                  ],
-                ),
-                trailing: IconButton(
-                  icon: Icon(Icons.favorite_border),
-                  onPressed: () {
-                    // Implement the favorite functionality here
-                  },
-                ),
-                onTap: () {
-                  // Implement tap action here (e.g., go to recipe details page)
-                },
+      backgroundColor: const Color(0xFFF5F5F5),
+      body: Column(
+        children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.fromLTRB(20, 60, 20, 20),
+            decoration: const BoxDecoration(
+              color: Color(0xFFB4436C),
+              borderRadius: BorderRadius.vertical(bottom: Radius.circular(30)),
+            ),
+            child: const Text(
+              'Based on your\ningredients:',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
               ),
-            );
-          },
-        ),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: recipes.length,
+              itemBuilder: (context, index) {
+                final recipe = recipes[index];
+                return GestureDetector(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => RecipeIngredientsPage(),
+                      ),
+                    );
+                  },
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 16),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(16),
+                      boxShadow: const [
+                        BoxShadow(
+                          color: Colors.black12,
+                          blurRadius: 4,
+                          offset: Offset(0, 2),
+                        )
+                      ],
+                    ),
+                    child: Column(
+                      children: [
+                        Stack(
+                          children: [
+                            ClipRRect(
+                              borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+                              child: Image.asset(
+                                recipe.imageUrl,
+                                height: 160,
+                                width: double.infinity,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                            Positioned(
+                              right: 10,
+                              top: 10,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: _getDifficultyColor(recipe.difficulty),
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  recipe.difficulty,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.all(12.0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                recipe.title,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Row(
+                                    children: [
+                                      const Icon(Icons.access_time, size: 16),
+                                      const SizedBox(width: 4),
+                                      Text('${recipe.cookingTime} min'),
+                                    ],
+                                  ),
+                                  IconButton(
+                                    icon: Icon(
+                                      recipe.isFavorite
+                                          ? Icons.favorite
+                                          : Icons.favorite_border,
+                                      color: recipe.isFavorite
+                                          ? Colors.red.shade800
+                                          : null, // dark red when filled
+                                    ),
+                                    onPressed: () => _toggleFavorite(index),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }
-
-  }
+}

--- a/frontend/lib/pages/recipes/recipes_page.dart
+++ b/frontend/lib/pages/recipes/recipes_page.dart
@@ -98,47 +98,47 @@ class _RecipesPageState extends State<RecipesPage> {
     }
   }
 
-Future<void> _generateRecipes() async {
-  try {
-    final recipeResults = await _recipeService.generateRecipes(
-      ingredients: ingredients,
-      dietaries: useDietaryRestrictions
-          ? selectedDietaries.map((d) => d.id!).toList()
-          : [],
-      appliances: selectedAppliances.map((a) => a.id).toList(),
-      difficultyLevel: selectedDifficulty,
-    );
+  Future<void> _generateRecipes() async {
+    try {
+      final recipeResults = await _recipeService.generateRecipes(
+        ingredients: ingredients,
+        dietaries:
+            useDietaryRestrictions
+                ? selectedDietaries.map((d) => d.id!).toList()
+                : [],
+        appliances: selectedAppliances.map((a) => a.id).toList(),
+        difficultyLevel: selectedDifficulty,
+      );
 
-    _logger.d(recipeResults);
+      _logger.d(recipeResults);
 
-    if (!mounted) return;
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => const RecipeRecommendationsPage(),
-      ),
-    );
-  } catch (e) {
-    if (!mounted) return;
+      if (!mounted) return;
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const RecipeRecommendationsPage(),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
 
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('Error'),
-          content: Text('Failed to generate recipes: ${e.toString()}'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        );
-      },
-    );
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('Error'),
+            content: Text('Failed to generate recipes: ${e.toString()}'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          );
+        },
+      );
+    }
   }
-}
-
 
   @override
   void dispose() {

--- a/frontend/lib/pages/recipes/recipes_page.dart
+++ b/frontend/lib/pages/recipes/recipes_page.dart
@@ -8,6 +8,7 @@ import 'package:nibbles/service/appliance/appliance_service.dart';
 import 'package:nibbles/service/profile/dietary_dto.dart';
 import 'package:nibbles/service/profile/profile_service.dart';
 import 'package:nibbles/service/recipe/recipe_service.dart';
+import 'package:nibbles/pages/recipes/recipe_recommendations_page.dart';
 
 class RecipesPage extends StatefulWidget {
   const RecipesPage({super.key});
@@ -97,39 +98,47 @@ class _RecipesPageState extends State<RecipesPage> {
     }
   }
 
-  Future<void> _generateRecipes() async {
-    try {
-      final recipeResults = await _recipeService.generateRecipes(
-        ingredients: ingredients,
-        dietaries:
-            useDietaryRestrictions
-                ? selectedDietaries.map((d) => d.id!).toList()
-                : [],
-        appliances: selectedAppliances.map((a) => a.id).toList(),
-        difficultyLevel: selectedDifficulty,
-      );
+Future<void> _generateRecipes() async {
+  try {
+    final recipeResults = await _recipeService.generateRecipes(
+      ingredients: ingredients,
+      dietaries: useDietaryRestrictions
+          ? selectedDietaries.map((d) => d.id!).toList()
+          : [],
+      appliances: selectedAppliances.map((a) => a.id).toList(),
+      difficultyLevel: selectedDifficulty,
+    );
 
-      _logger.d(recipeResults);
-    } catch (e) {
-      if (!mounted) return;
+    _logger.d(recipeResults);
 
-      showDialog(
-        context: context,
-        builder: (BuildContext context) {
-          return AlertDialog(
-            title: const Text('Error'),
-            content: Text('Failed to generate recipes: ${e.toString()}'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('OK'),
-              ),
-            ],
-          );
-        },
-      );
-    }
+    if (!mounted) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const RecipeRecommendationsPage(),
+      ),
+    );
+  } catch (e) {
+    if (!mounted) return;
+
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Error'),
+          content: Text('Failed to generate recipes: ${e.toString()}'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
   }
+}
+
 
   @override
   void dispose() {


### PR DESCRIPTION
recipe_recommendations_page that shows up once generate recipes on the recipe_page is clicked.
I have made edits to recipe_page in this so that when generate recipes is clicked if it is a success it will redirect to this page.
Additionally when the filtering option is clicked it takes you back to the recipes_page so you can edit the filters there.
Right now the reload hasnt been implemented because it depends on backend being implemented. 