### PR TITLE
fix: changed error from lower camel case to Full Spaced version

### DIFF
--- a/frontend/lib/pages/map_page.dart
+++ b/frontend/lib/pages/map_page.dart
@@ -121,7 +121,9 @@ class _MapPageState extends State<MapPage> {
     }
 
     // Only set up location stream if using current location
-    _positionStreamSubscription = Geolocator.getPositionStream().listen((Position pos) {
+    _positionStreamSubscription = Geolocator.getPositionStream().listen((
+      Position pos,
+    ) {
       final newPos = LatLng(pos.latitude, pos.longitude);
       if (mounted) {
         setState(() {

--- a/frontend/lib/pages/profile/personal_info_page.dart
+++ b/frontend/lib/pages/profile/personal_info_page.dart
@@ -449,15 +449,19 @@ class PersonalInfoPageState extends State<PersonalInfoPage> {
 
   Future<void> _handleFieldUpdate(String fieldName, String newValue) async {
     UpdateUserDto? data;
+    String displayFieldName = fieldName;
     switch (fieldName) {
       case 'firstName':
         data = UpdateUserDto(firstName: newValue);
+        displayFieldName = 'First Name';
         break;
       case 'lastName':
         data = UpdateUserDto(lastName: newValue);
+        displayFieldName = 'Last Name';
         break;
       case 'email':
         data = UpdateUserDto(email: newValue);
+        displayFieldName = 'Email';
         break;
       default:
         return;
@@ -468,11 +472,11 @@ class PersonalInfoPageState extends State<PersonalInfoPage> {
       await _loadUserInfo(); // Reload user info to reflect the changes
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('$fieldName updated successfully!')),
+          SnackBar(content: Text('$displayFieldName updated successfully!')),
         );
       }
     } catch (error) {
-      _logger.d('Error updating $fieldName: $error');
+      _logger.d('Error updating $displayFieldName: $error');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('An error occurred while updating.')),


### PR DESCRIPTION
This PR adds:
- Fixed the message at the bottom to display full spaced rather than lower camel case when updating user details